### PR TITLE
XDS stream actor - silent stream detection with full channel recreation

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -19,6 +19,7 @@ akka {
 sidecar {
   host = "localhost"
   port = 8080
+  xds-silent-restart-seconds = 30
 }
 
 application {

--- a/src/main/scala/io/hydrosphere/serving/gateway/GatewayRuntimeApp.scala
+++ b/src/main/scala/io/hydrosphere/serving/gateway/GatewayRuntimeApp.scala
@@ -33,15 +33,10 @@ object GatewayRuntimeApp extends App with Logging {
           sys.exit(1)
       }
     }
-
-    applicationUpdater.getUpdates()
-
     logger.info("Initialization completed")
   } catch {
     case e: Throwable =>
       logger.error("Fatal error", e)
       sys.exit(1)
   }
-
-  println(scala.io.StdIn.readLine())
 }

--- a/src/main/scala/io/hydrosphere/serving/gateway/config/Configuration.scala
+++ b/src/main/scala/io/hydrosphere/serving/gateway/config/Configuration.scala
@@ -4,7 +4,8 @@ import org.apache.logging.log4j.scala.Logging
 
 case class SidecarConfig(
   host: String,
-  port: Int
+  port: Int,
+  xdsSilentRestartSeconds: Long
 )
 
 case class ApplicationConfig(
@@ -12,7 +13,7 @@ case class ApplicationConfig(
   httpPort: Int,
   shadowingOn: Boolean,
   profilingDestination: String,
-  monitoringDestination: String
+  monitoringDestination: String,
 )
 
 final case class Configuration(

--- a/src/main/scala/io/hydrosphere/serving/gateway/config/Inject.scala
+++ b/src/main/scala/io/hydrosphere/serving/gateway/config/Inject.scala
@@ -46,18 +46,18 @@ object Inject extends Logging {
   builder.enableRetry()
   builder.usePlaintext()
 
-  implicit val sidecarChannel: Channel = ClientInterceptors
+  val sidecarChannel: Channel = ClientInterceptors
     .intercept(builder.build, new AuthorityReplacerInterceptor +: Headers.interceptors: _*)
 
-  implicit val predictGrpcClient = PredictionServiceGrpc.stub(sidecarChannel)
-  implicit val profilerGrpcClient = DataProfilerServiceGrpc.stub(sidecarChannel)
-  implicit val monitoringGrpcClient = MonitoringServiceGrpc.stub(sidecarChannel)
+  val predictGrpcClient = PredictionServiceGrpc.stub(sidecarChannel)
+  val profilerGrpcClient = DataProfilerServiceGrpc.stub(sidecarChannel)
+  val monitoringGrpcClient = MonitoringServiceGrpc.stub(sidecarChannel)
 
   logger.debug(s"Initializing application storage")
   implicit val applicationStorage = new ApplicationStorageImpl()
 
   logger.debug(s"Initializing application update service")
-  implicit val applicationUpdater = new XDSApplicationUpdateService(applicationStorage, sidecarChannel)
+  implicit val applicationUpdater = new XDSApplicationUpdateService(applicationStorage, appConfig.sidecar)
 
   logger.debug("Initializing app execution service")
   implicit val gatewayPredictionService = new ApplicationExecutionServiceImpl(

--- a/src/main/scala/io/hydrosphere/serving/gateway/grpc/GrpcPredictionService.scala
+++ b/src/main/scala/io/hydrosphere/serving/gateway/grpc/GrpcPredictionService.scala
@@ -13,6 +13,7 @@ class GrpcPredictionService(
 )(implicit ec: ExecutionContext) extends PredictionService with Logging {
 
   override def predict(request: PredictRequest): Future[PredictResponse] = {
+    logger.info(s"Got grpc request modelSpec=${request.modelSpec}")
     request.modelSpec match {
       case Some(_) =>
         val requestId = Option(Headers.XRequestId.contextKey.get())


### PR DESCRIPTION
Enabling empty responses on manager allows the gateway to control the state of the stream.

If stream silently fails again - XDS actor will detect the absence of responses in a period of time and recreate it.